### PR TITLE
Fixed FileClient.Get to use V4 api when appropriate

### DIFF
--- a/NGitLab/NGitLab.Tests/Config.cs
+++ b/NGitLab/NGitLab.Tests/Config.cs
@@ -4,7 +4,7 @@
         public const string Secret = "y1ZcmHSidM4bqwYzjFPU";
 
         public static GitLabClient Connect() {
-            return GitLabClient.Connect(ServiceUrl,"maikebing","kissme", Impl.Api.ApiVersion.V3_1);
+            return GitLabClient.Connect(ServiceUrl,"maikebing","kissme", Impl.ApiVersion.V3_1);
         }
     }
 }

--- a/NGitLab/NGitLab/GitLabClient.cs
+++ b/NGitLab/NGitLab/GitLabClient.cs
@@ -11,10 +11,10 @@ namespace NGitLab {
         public readonly IProjectClient Projects;
         public readonly IUserClient Users;
         public string ApiToken => api.ApiToken;
-        GitLabClient(string hostUrl, string apiToken) : this(hostUrl, apiToken, Api.ApiVersion.V4)
+        GitLabClient(string hostUrl, string apiToken) : this(hostUrl, apiToken, ApiVersion.V4)
         {
         }
-        GitLabClient(string hostUrl, string apiToken, Api.ApiVersion apiVersion)
+        GitLabClient(string hostUrl, string apiToken, ApiVersion apiVersion)
         {
             api = new Api(hostUrl, apiToken);
             api._ApiVersion = apiVersion;
@@ -25,35 +25,29 @@ namespace NGitLab {
         }
         public static GitLabClient Connect(string hostUrl, string username, string password)
         {
-            return Connect(hostUrl, username, password, Api.ApiVersion.V4_Oauth);
+            return Connect(hostUrl, username, password, ApiVersion.V4_Oauth);
         }
-        public static GitLabClient Connect(string hostUrl, string username, string password,Api.ApiVersion apiVersion)
+        public static GitLabClient Connect(string hostUrl, string username, string password, ApiVersion apiVersion)
         {
             var api = new Api(hostUrl, "");
             api._ApiVersion = apiVersion;
             string PrivateToken = null;
-            switch (apiVersion)
 
+            if (apiVersion.UsesOauth())
             {
-                case Api.ApiVersion.V3_1:
-                case Api.ApiVersion.V3:
-                case Api.ApiVersion.V4:
-                    var session = api.Post().To<Session>($"/session?{(apiVersion== Api.ApiVersion.V3_1?"email":"login")}={HttpUtility.UrlEncode(username)}&password={HttpUtility.UrlEncode(password)}");
-                    PrivateToken = session.PrivateToken;
-                    break;
-                case Api.ApiVersion.V3_Oauth:
-                case Api.ApiVersion.V4_Oauth:
-                    //https://docs.gitlab.com/ee/api/oauth2.html#resource-owner-password-credentials
-                    var token    = api.Post().With(new oauth() { UserName =username, Password = password, GrantType = "password" }).To<token>(oauth.Url);
-                    PrivateToken = token.AccessToken;
-                    break;
-                default:
-                    break;
+                //https://docs.gitlab.com/ee/api/oauth2.html#resource-owner-password-credentials
+                var token    = api.Post().With(new oauth() { UserName =username, Password = password, GrantType = "password" }).To<token>(oauth.Url);
+                PrivateToken = token.AccessToken;
+            }
+            else
+            {
+                var session = api.Post().To<Session>($"/session?{(apiVersion== ApiVersion.V3_1?"email":"login")}={HttpUtility.UrlEncode(username)}&password={HttpUtility.UrlEncode(password)}");
+                PrivateToken = session.PrivateToken;
             }
             return Connect(hostUrl, PrivateToken, apiVersion);
         }
         
-        public static GitLabClient Connect(string hostUrl, string apiToken,  Api.ApiVersion apiVersion)
+        public static GitLabClient Connect(string hostUrl, string apiToken,  ApiVersion apiVersion)
         {
             return new GitLabClient(hostUrl, apiToken, apiVersion);
         }

--- a/NGitLab/NGitLab/Impl/API.cs
+++ b/NGitLab/NGitLab/Impl/API.cs
@@ -4,14 +4,6 @@ using System.Diagnostics;
 namespace NGitLab.Impl {
     //[DebuggerStepThrough]
     public class Api {
-        public enum ApiVersion
-        {
-            V3,
-            V4,
-            V3_Oauth,
-            V4_Oauth,
-            V3_1
-        }
         readonly string hostUrl;
         public readonly string ApiToken;
          internal     ApiVersion _ApiVersion { get; set; } = ApiVersion.V4_Oauth;
@@ -43,7 +35,7 @@ namespace NGitLab.Impl {
         public Uri GetApiUrl(string tailApiUrl) {
             if (!tailApiUrl.StartsWith("/"))
                 tailApiUrl = "/" + tailApiUrl;
-            return new Uri($"{hostUrl}{(hostUrl.EndsWith("/")?"":"/")}api/{((_ApiVersion== ApiVersion.V3 || _ApiVersion== ApiVersion.V3_1) ?"v3":"v4")}{tailApiUrl}");
+            return new Uri($"{hostUrl}{(hostUrl.EndsWith("/")?"":"/")}api/{(_ApiVersion.IsV3() ?"v3":"v4")}{tailApiUrl}");
         }
 
         public Uri GetUrl(string tailApiUrl) {

--- a/NGitLab/NGitLab/Impl/ApiVersion.cs
+++ b/NGitLab/NGitLab/Impl/ApiVersion.cs
@@ -1,0 +1,29 @@
+namespace NGitLab.Impl
+{
+    public enum ApiVersion
+    {
+        V3,
+        V4,
+        V3_Oauth,
+        V4_Oauth,
+        V3_1
+    }
+
+    static class ApiVersionMethods
+    {
+        public static bool IsV4(this ApiVersion apiVersion)
+        {
+            return apiVersion == ApiVersion.V4 || apiVersion == ApiVersion.V4_Oauth;
+        }
+        
+        public static bool IsV3(this ApiVersion apiVersion)
+        {
+            return !apiVersion.IsV4();
+        }
+
+        public static bool UsesOauth(this ApiVersion apiVersion)
+        {
+            return apiVersion == ApiVersion.V3_Oauth || apiVersion == ApiVersion.V4_Oauth;
+        }
+    }
+}

--- a/NGitLab/NGitLab/Impl/FileClient.cs
+++ b/NGitLab/NGitLab/Impl/FileClient.cs
@@ -31,7 +31,7 @@ namespace NGitLab.Impl {
             if (branch == "")
                 branch = "master";
 
-            if (api._ApiVersion == Api.ApiVersion.V4 || api._ApiVersion == Api.ApiVersion.V4_Oauth)
+            if (api._ApiVersion.IsV4())
             {
                 filePath = $"/files/{filePath}?ref={branch}";
             }

--- a/NGitLab/NGitLab/Impl/FileClient.cs
+++ b/NGitLab/NGitLab/Impl/FileClient.cs
@@ -31,7 +31,16 @@ namespace NGitLab.Impl {
             if (branch == "")
                 branch = "master";
 
-            api.Get().Stream(repoPath + string.Format("/files?file_path={0}&ref={1}", filePath, branch), s =>
+            if (api._ApiVersion == Api.ApiVersion.V4 || api._ApiVersion == Api.ApiVersion.V4_Oauth)
+            {
+                filePath = $"/files/{filePath}?ref={branch}";
+            }
+            else
+            {
+                filePath = $"/files?file_path={filePath}&ref={branch}";
+            }
+
+            api.Get().Stream(repoPath + filePath, s =>
             {
                 if (parser != null)
                     parser(s);

--- a/NGitLab/NGitLab/Impl/HttpRequestor.cs
+++ b/NGitLab/NGitLab/Impl/HttpRequestor.cs
@@ -132,12 +132,12 @@ namespace NGitLab.Impl {
 
       
        
-        static WebRequest SetupConnection(Uri url, MethodType methodType, string privateToken, Api.ApiVersion apiVersion) {
+        static WebRequest SetupConnection(Uri url, MethodType methodType, string privateToken, ApiVersion apiVersion) {
             var request = (HttpWebRequest)WebRequest.Create(url);
             request.Method = methodType.ToString().ToUpperInvariant();
             request.Headers.Add("Accept-Encoding", "gzip");
             request.AutomaticDecompression = DecompressionMethods.GZip;
-            if (apiVersion == Api.ApiVersion.V3_Oauth || apiVersion == Api.ApiVersion.V4_Oauth)
+            if (apiVersion.UsesOauth())
             {
                 request.Headers["Authorization"] = "Bearer " + privateToken;
             }
@@ -158,8 +158,8 @@ namespace NGitLab.Impl {
         class Enumerable<T> : IEnumerable<T> {
             readonly string apiToken;
             readonly Uri startUrl;
-           readonly Api.ApiVersion _apiVersion;
-            public Enumerable(string apiToken, Uri startUrl, Api.ApiVersion _ApiVersion) {
+           readonly ApiVersion _apiVersion;
+            public Enumerable(string apiToken, Uri startUrl, ApiVersion _ApiVersion) {
                 this.apiToken = apiToken;
                 this.startUrl = startUrl;
                 _apiVersion = _ApiVersion;
@@ -175,11 +175,11 @@ namespace NGitLab.Impl {
 
             class Enumerator : IEnumerator<T> {
                 readonly string apiToken;
-                readonly Api.ApiVersion _apiVersion;
+                readonly ApiVersion _apiVersion;
                 readonly List<T> buffer = new List<T>();
                 Uri nextUrlToLoad;
 
-                public Enumerator(string apiToken, Uri startUrl, Api.ApiVersion _ApiVersion) {
+                public Enumerator(string apiToken, Uri startUrl, ApiVersion _ApiVersion) {
                     this.apiToken = apiToken;
                     nextUrlToLoad = startUrl;
                     _apiVersion = _ApiVersion;
@@ -194,7 +194,7 @@ namespace NGitLab.Impl {
                             return false;
 
                         var request = SetupConnection(nextUrlToLoad, MethodType.Get, apiToken, _apiVersion);
-                        if (_apiVersion == Api.ApiVersion.V3_Oauth || _apiVersion == Api.ApiVersion.V4_Oauth)
+                        if (_apiVersion.UsesOauth())
                         {
                             request.Headers["Authorization"] = "Bearer " + apiToken;
                         }


### PR DESCRIPTION
The GitLab get file api changed from v3 to v4.


Ref: https://docs.gitlab.com/ce/api/v3_to_v4.html

I also added some extension methods to the ApiVersion Enum for more convenient usage.