### PR TITLE
The FileClient doesn't work anymore

### DIFF
--- a/NGitLab/NGitLab/Impl/FileClient.cs
+++ b/NGitLab/NGitLab/Impl/FileClient.cs
@@ -12,16 +12,25 @@ namespace NGitLab.Impl {
             this.repoPath = repoPath;
         }
 
+        private string GetFilePath(string filePath, string branch)
+        {
+            filePath = System.Web.HttpUtility.UrlEncode(filePath);
+
+            return api._ApiVersion.IsV4()
+                ? $"/files/{filePath}?ref={branch}"
+                : $"/files?file_path={filePath}&ref={branch}";
+        }
+
         public void Create(FileUpsert file) {
-            api.Post().With(file).Stream(repoPath + "/files", s => { });
+            api.Post().With(file).Stream(repoPath + GetFilePath(file.Path, file.Branch), s => { });
         }
 
         public void Update(FileUpsert file) {
-            api.Put().With(file).Stream(repoPath + "/files", s => { });
+            api.Put().With(file).Stream(repoPath + GetFilePath(file.Path, file.Branch), s => { });
         }
 
         public void Delete(FileDelete file) {
-            api.Delete().With(file).Stream(repoPath + "/files", s => { });
+            api.Delete().With(file).Stream(repoPath + GetFilePath(file.Path, file.Branch), s => { });
         }
 
         public FileData Get(string filePath, string branch = "", System.Action<System.IO.Stream> parser = null)
@@ -31,14 +40,7 @@ namespace NGitLab.Impl {
             if (branch == "")
                 branch = "master";
 
-            if (api._ApiVersion.IsV4())
-            {
-                filePath = $"/files/{filePath}?ref={branch}";
-            }
-            else
-            {
-                filePath = $"/files?file_path={filePath}&ref={branch}";
-            }
+            filePath = $"{GetFilePath(filePath, branch)}";
 
             api.Get().Stream(repoPath + filePath, s =>
             {

--- a/NGitLab/NGitLab/Models/FileDelete.cs
+++ b/NGitLab/NGitLab/Models/FileDelete.cs
@@ -9,7 +9,7 @@ namespace NGitLab.Models {
         public string Path { get; set; }
 
         [Required]
-        [DataMember(Name = "branch_name")]
+        [DataMember(Name = "branch")]
         public string Branch { get; set; }
 
         [Required]

--- a/NGitLab/NGitLab/Models/FileUpsert.cs
+++ b/NGitLab/NGitLab/Models/FileUpsert.cs
@@ -9,7 +9,7 @@ namespace NGitLab.Models {
         public string Path { get; set; }
 
         [Required]
-        [DataMember(Name = "branch_name")]
+        [DataMember(Name = "branch")]
         public string Branch { get; set; }
 
         [DataMember(Name = "encoding")]


### PR DESCRIPTION
As the document describe: [https://docs.gitlab.com/ee/api/repository_files.html]
1. The file path should always included as part of request url. But the file client was including it as part of JSON payload for post/put/delete.

2. According to the sample of the document, the file path has to be url encoded. 

3. The branch name field is "branch" rather than "branch_name"