### PR TITLE
Added ContentLength as Parameter for Parser Callback of Stream-Method (HttpRequestor)

### DIFF
--- a/NGitLab/NGitLab/IFilesClient.cs
+++ b/NGitLab/NGitLab/IFilesClient.cs
@@ -5,6 +5,6 @@ namespace NGitLab {
         void Create(FileUpsert file);
         void Update(FileUpsert file);
         void Delete(FileDelete file);
-        FileData Get(string filePath, string branch = "", System.Action<System.IO.Stream> parser = null);
+        FileData Get(string filePath, string branch = "", System.Action<System.IO.Stream, long> parser = null);
     }
 }

--- a/NGitLab/NGitLab/Impl/FileClient.cs
+++ b/NGitLab/NGitLab/Impl/FileClient.cs
@@ -24,19 +24,21 @@ namespace NGitLab.Impl {
             api.Delete().With(file).Stream(repoPath + "/files", s => { });
         }
 
-        public FileData Get(string filePath, string branch = "", System.Action<System.IO.Stream> parser = null)
+        public FileData Get(string filePath, string branch = "", System.Action<System.IO.Stream, long> parser = null)
         {
             FileData fileData = null;
 
             if (branch == "")
                 branch = "master";
 
-            api.Get().Stream(repoPath + string.Format("/files?file_path={0}&ref={1}", filePath, branch), s =>
+            api.Get().Stream(repoPath + string.Format("/files?file_path={0}&ref={1}", filePath, branch), (stream, length) =>
             {
-                if (parser != null)
-                    parser(s);
-
-                StreamReader sr = new StreamReader(s);
+                if (parser != null) { 
+                    parser(stream, length);
+                    return;
+                }
+                
+                StreamReader sr = new StreamReader(stream);
                 var content = sr.ReadToEnd();
                 fileData = JsonConvert.DeserializeObject<FileData>(content);
             });

--- a/NGitLab/NGitLab/Impl/HttpRequestor.cs
+++ b/NGitLab/NGitLab/Impl/HttpRequestor.cs
@@ -43,7 +43,15 @@ namespace NGitLab.Impl {
             return result;
         }
 
-        public void Stream(string tailApiUrl, Action<Stream> parser) {
+        public void Stream(string tailApiUrl, Action<Stream> parser)
+        {
+            Stream(tailApiUrl, (stream, contentLength) =>
+            {
+                parser(stream);
+            });
+        }
+
+        public void Stream(string tailApiUrl, Action<Stream, long> parser) {
             var req = SetupConnection(root.GetApiUrl(tailApiUrl));
 
             if (HasOutput())
@@ -54,7 +62,7 @@ namespace NGitLab.Impl {
             try {
                 using (var response = req.GetResponse()) {
                     using (var stream = response.GetResponseStream()) {
-                        parser(stream);
+                        parser(stream, req.ContentLength);
                     }
                 }
             }

--- a/NGitLab/NGitLab/Impl/HttpRequestor.cs
+++ b/NGitLab/NGitLab/Impl/HttpRequestor.cs
@@ -62,7 +62,7 @@ namespace NGitLab.Impl {
             try {
                 using (var response = req.GetResponse()) {
                     using (var stream = response.GetResponseStream()) {
-                        parser(stream, req.ContentLength);
+                        parser(stream, response.ContentLength);
                     }
                 }
             }


### PR DESCRIPTION
As I wanted to implement my own Parser/Downloader I needed the stream content length. I added this as Parser Callback Parameter.