### PR TITLE
Added Deploy Key API

### DIFF
--- a/NGitLab/NGitLab/GitLabClient.cs
+++ b/NGitLab/NGitLab/GitLabClient.cs
@@ -10,6 +10,8 @@ namespace NGitLab {
         public readonly IIssueClient Issues;
         public readonly IProjectClient Projects;
         public readonly IUserClient Users;
+        public readonly IDeployKeyClient DeployKeys;
+
         public string ApiToken => api.ApiToken;
         GitLabClient(string hostUrl, string apiToken) : this(hostUrl, apiToken, ApiVersion.V4)
         {
@@ -22,6 +24,7 @@ namespace NGitLab {
             Projects = new ProjectClient(api);
             Issues = new IssueClient(api);
             Groups = new NamespaceClient(api);
+            DeployKeys = new DeployKeyClient(api);
         }
         public static GitLabClient Connect(string hostUrl, string username, string password)
         {

--- a/NGitLab/NGitLab/IDeployKeyClient.cs
+++ b/NGitLab/NGitLab/IDeployKeyClient.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using NGitLab.Models;
+
+namespace NGitLab {
+    public interface IDeployKeyClient {
+        /// <summary>
+        ///     Get a list of all deploy keys
+        /// </summary>
+        IEnumerable<DeployKey> Get();
+
+        /// <summary>
+        ///     Get a list of deploy keys for the specified project.
+        /// </summary>
+        IEnumerable<DeployKey> Get(int projectId);
+
+        /// <summary>
+        ///     Enables a deploy key on a project.  Returns the enabled deploy key on success.
+        /// </summary>
+        DeployKey Enable(int projectId, int deployKeyId);
+    }
+}

--- a/NGitLab/NGitLab/IDeployKeyClient.cs
+++ b/NGitLab/NGitLab/IDeployKeyClient.cs
@@ -17,5 +17,15 @@ namespace NGitLab {
         ///     Enables a deploy key on a project.  Returns the enabled deploy key on success.
         /// </summary>
         DeployKey Enable(int projectId, int deployKeyId);
+
+        /// <summary>
+        ///     Updates a deploy key on a project.  Returns the updated deploy key on success.
+        /// </summary>
+        DeployKey Update(int projectId, DeployKey key);
+
+        /// <summary>
+        ///     Deletes a deploy key from a project.
+        /// </summary>
+        void Delete(int projectId, int deployKeyId);
     }
 }

--- a/NGitLab/NGitLab/Impl/DeployKeyClient.cs
+++ b/NGitLab/NGitLab/Impl/DeployKeyClient.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using NGitLab.Models;
+
+namespace NGitLab.Impl {
+    public class DeployKeyClient : IDeployKeyClient {
+        const string DeployKeysUrl = "/deploy_keys";
+        const string ProjectDeployKeysUrl = "/projects/{0}/deploy_keys";
+        const string ProjectDeployKeyEnableUrl = "/projects/{0}/deploy_keys/{1}/enable";
+        readonly Api api;
+
+        public DeployKeyClient(Api api) {
+            this.api = api;
+        }
+
+        public IEnumerable<DeployKey> Get() {
+            return api.Get().GetAll<DeployKey>(DeployKeysUrl);
+        }
+
+        public IEnumerable<DeployKey> Get(int projectId) {
+            return api.Get().GetAll<DeployKey>(string.Format(ProjectDeployKeysUrl, projectId));
+        }
+
+        public DeployKey Enable(int projectId, int deployKeyId)
+        {
+            return api.Post().To<DeployKey>(string.Format(ProjectDeployKeyEnableUrl, projectId, deployKeyId));
+        }
+    }
+}

--- a/NGitLab/NGitLab/Impl/DeployKeyClient.cs
+++ b/NGitLab/NGitLab/Impl/DeployKeyClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NGitLab.Models;
 
 namespace NGitLab.Impl {
@@ -6,6 +7,7 @@ namespace NGitLab.Impl {
         const string DeployKeysUrl = "/deploy_keys";
         const string ProjectDeployKeysUrl = "/projects/{0}/deploy_keys";
         const string ProjectDeployKeyEnableUrl = "/projects/{0}/deploy_keys/{1}/enable";
+        const string ProjectDeployKeyUpdateUrl = "/projects/{0}/deploy_keys/{1}";
         readonly Api api;
 
         public DeployKeyClient(Api api) {
@@ -23,6 +25,21 @@ namespace NGitLab.Impl {
         public DeployKey Enable(int projectId, int deployKeyId)
         {
             return api.Post().To<DeployKey>(string.Format(ProjectDeployKeyEnableUrl, projectId, deployKeyId));
+        }
+
+        public DeployKey Update(int projectId, DeployKey key)
+        {
+            if(key == null)
+            {
+                throw new ArgumentException($"{nameof(key)} is required and cannot be null");
+            }
+
+            return api.Put().With(key).To<DeployKey>(string.Format(ProjectDeployKeyUpdateUrl, projectId, key.Id));
+        }
+
+        public void Delete(int projectId, int deployKeyId)
+        {
+            api.Delete().To<DeployKey>(string.Format(ProjectDeployKeyUpdateUrl, projectId, deployKeyId));
         }
     }
 }

--- a/NGitLab/NGitLab/Models/DeployKey.cs
+++ b/NGitLab/NGitLab/Models/DeployKey.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace NGitLab.Models {
+    [DataContract]
+    public class DeployKey {
+        [DataMember(Name = "id")]
+        public int Id { get; set; }
+
+        [DataMember(Name = "title")]
+        public string Title { get; set; }
+
+        [DataMember(Name = "key")]
+        public string Key { get; set; }
+
+        [DataMember(Name = "created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [DataMember(Name = "can_push")]
+        public bool CanPush { get; set; }
+    }
+}


### PR DESCRIPTION
Implements #25 

Changes:
* Added Deploy Key Api 
  * Get all deploy keys (all projects)
  * Get all deploy keys for a project
  * Enable deploy key for a project
  * Update deploy key for a project
  * Delete deploy key for a project

I was able to test it locally using my own unit test project, unfortunately I can't add it to your unit tests as I'm not on Windows and the unit tests are .NET Framework.  
